### PR TITLE
feat: improve calculators UI with material tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>CalcSlide</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -29,19 +32,19 @@
           <div class="rule-three-row">
             <input type="number" id="inputC" step="any" placeholder="C" />
             <span class="rule-three-label">IS TO</span>
-            <input type="text" id="inputX" placeholder="X" disabled style="font-weight:bold; font-size:1.2em;" />
+            <input type="text" id="inputX" placeholder="X" readonly class="output-field" />
           </div>
         </div>
-        <button type="submit" style="margin-top:30px;">Calculate</button>
+        <button type="submit" class="mt-30">Calculate</button>
         <div class="result" id="ruleOfThreeResultText"></div>
       </form>
 
       <form id="leverageCalculator" class="calculator">
         <h2>Leverage Calculator</h2>
         <label>Leverage:</label>
-        <input type="number" id="leverage" />
+        <input type="number" id="leverage" step="any" />
         <label>Percentage Earned (%):</label>
-        <input type="number" id="percentage" />
+        <input type="number" id="percentage" step="any" />
         <button type="submit">Calculate</button>
         <div class="result" id="leveragedProfitResultText"></div>
       </form>
@@ -49,9 +52,9 @@
       <form id="profitCalculator" class="calculator">
         <h2>Profit Percentage Calculator</h2>
         <label>Lot Size ($):</label>
-        <input type="number" id="lotSize" />
+        <input type="number" id="lotSize" step="any" />
         <label>Profit Amount ($):</label>
-        <input type="number" id="profit" />
+        <input type="number" id="profit" step="any" />
         <button type="submit">Calculate</button>
         <div class="result" id="profitResultText"></div>
       </form>
@@ -59,13 +62,13 @@
       <form id="compoundInterestCalculator" class="calculator">
         <h2>Compound Interest Calculator</h2>
         <label>Initial Investment:</label>
-        <input type="number" id="initialInvestment" />
+        <input type="number" id="initialInvestment" step="any" />
         <label>Monthly Contribution:</label>
-        <input type="number" id="contribution" />
+        <input type="number" id="contribution" step="any" />
         <label>Rate (%):</label>
-        <input type="number" id="rate" />
+        <input type="number" id="rate" step="any" />
         <label>Period (Months):</label>
-        <input type="number" id="period" />
+        <input type="number" id="period" step="any" />
         <button type="submit">Calculate</button>
         <div class="result" id="compoundInterestResultText"></div>
       </form>
@@ -74,7 +77,7 @@
         <h2>B3 Profit Calculator</h2>
         <div class="form-group">
           <label for="contracts">Contracts:</label>
-          <input type="number" id="contracts" name="contracts" />
+          <input type="number" id="contracts" name="contracts" step="1" />
         </div>
         <div class="form-group">
           <label for="type">Type:</label>

--- a/script.js
+++ b/script.js
@@ -28,7 +28,7 @@ document.getElementById('ruleOfThreeCalculator').addEventListener('submit', func
     inputX.value = X.toFixed(4);
     resultDiv.textContent = `X = ${X.toFixed(4)}`;
   } else {
-    resultDiv.textContent = 'Please fill all fields.';
+    resultDiv.textContent = A === 0 ? 'A cannot be zero.' : 'Please fill all fields.';
     inputX.value = '';
   }
 });

--- a/style.css
+++ b/style.css
@@ -12,6 +12,7 @@ input[type=number] {
   --primary-bg: #1F1F1F;
   --card-bg: #2B2B2B;
   --input-bg: #3D3D3D;
+  --accent-color: #6200EE;
   --white: rgba(255,255,255,0.9);
   --white2: rgba(255,255,255,0.42);
   --white3: rgba(255,255,255,0.56);
@@ -22,10 +23,7 @@ input[type=number] {
 }
 
 body {
-  user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
-  font-family: Arial, sans-serif;
+  font-family: 'Roboto', Arial, sans-serif;
   background-color: var(--primary-bg);
   color: var(--white);
   margin: 0;
@@ -118,25 +116,42 @@ button[type="submit"] {
   padding: 12px;
   width: 100%;
   border-radius: 16px;
-  background-color: transparent;
+  background-color: var(--accent-color);
   color: var(--white);
-  border: 2px solid var(--white2);
+  border: none;
   cursor: pointer;
-  transition: background-color 0.3s, border-color 0.3s, color 0.3s;
+  position: relative;
+  overflow: hidden;
+  transition: background-color 0.3s, box-shadow 0.3s;
   margin-top: 20px;
 }
 
 button[type="submit"]:hover {
-  background-color: var(--white2);
-  color: var(--primary-bg);
-  border-color: var(--white3);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
 }
 
 button[type="submit"]:focus {
   outline: none;
-  background-color: var(--white3);
-  color: var(--primary-bg);
-  border-color: var(--white3);
+  box-shadow: 0 0 0 3px rgba(98,0,238,0.3);
+}
+
+button[type="submit"]::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255,255,255,0.3);
+  border-radius: 50%;
+  transform: scale(0);
+  opacity: 0;
+  transition: transform 0.3s, opacity 0.3s;
+}
+
+button[type="submit"]:active::after {
+  transform: scale(2);
+  opacity: 1;
 }
 
 .result {
@@ -173,12 +188,13 @@ button[type="submit"]:focus {
   font-weight: bold;
 }
 
-.rule-three-row input[disabled] {
+.output-field {
   font-weight: bold;
   font-size: 1.2em;
   background: var(--primary-bg);
   color: var(--white);
   text-align: center;
+  border: none;
 }
 
 .form-group {
@@ -195,4 +211,8 @@ label {
   align-items: center;
   gap: 8px;
   margin-top: 10px;
+}
+
+.mt-30 {
+  margin-top: 30px;
 }


### PR DESCRIPTION
## Summary
- integrate Roboto font and Material-inspired accent styling
- refine rule of three calculator validation
- enable decimal input across calculators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b08312ec832688b579198bce8f97