### PR TITLE
Refactor calculators and unify styles

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,105 +1,204 @@
-// Normal Calculator
-document.getElementById('calculator').addEventListener('submit', function(e){
-  e.preventDefault();
-  const expr = document.getElementById('operationInput').value.trim();
-  const resultDiv = document.getElementById('normalResultText');
-  if(expr){
-    try{
-      const result = math.evaluate(expr);
-      resultDiv.textContent = `Result: ${result}`;
-    }catch{
-      resultDiv.textContent = 'Invalid Expression!';
-    }
-  } else {
-    resultDiv.textContent = 'Please enter a valid expression.';
-  }
-});
+function clearResult(form) {
+  form.querySelectorAll('.result').forEach(r => (r.innerText = ''));
+}
 
-// Rule of Three (Novo formato)
-document.getElementById('ruleOfThreeCalculator').addEventListener('submit', function(e){
-  e.preventDefault();
-  const A = parseFloat(document.getElementById('inputA').value);
-  const B = parseFloat(document.getElementById('inputB').value);
-  const C = parseFloat(document.getElementById('inputC').value);
-  const resultDiv = document.getElementById('ruleOfThreeResultText');
-  const inputX = document.getElementById('inputX');
-  if (!isNaN(A) && !isNaN(B) && !isNaN(C) && A !== 0) {
-    const X = (B * C) / A;
-    inputX.value = X.toFixed(4);
-    resultDiv.textContent = `X = ${X.toFixed(4)}`;
-  } else {
-    resultDiv.textContent = A === 0 ? 'A cannot be zero.' : 'Please fill all fields.';
-    inputX.value = '';
-  }
-});
+function showError(form, msg, resultEl) {
+  clearResult(form);
+  const el = resultEl || form.querySelector('.result');
+  if (el) el.innerText = 'Error: ' + msg;
+}
 
-// Leverage
-document.getElementById('leverageCalculator').addEventListener('submit', function(e){
-  e.preventDefault();
-  const leverage = parseFloat(document.getElementById('leverage').value);
-  const percentage = parseFloat(document.getElementById('percentage').value);
-  const resultDiv = document.getElementById('leveragedProfitResultText');
-  if (!isNaN(leverage) && !isNaN(percentage)) {
-    const result = leverage * percentage;
-    resultDiv.textContent = `Leverage Profit: ${result.toFixed(2)}`;
-  } else {
-    resultDiv.textContent = 'Please fill all fields.';
-  }
-});
+function showCalculator(calculatorId) {
+  document
+    .querySelectorAll('.calculator')
+    .forEach(calc => calc.classList.remove('show'));
+  const target = document.getElementById(calculatorId);
+  if (target) target.classList.add('show');
+  document.querySelectorAll('.toggle-button').forEach(btn => {
+    btn.classList.toggle('active', btn.getAttribute('data-id') === calculatorId);
+  });
+}
 
-// Profit percentage
-document.getElementById('profitCalculator').addEventListener('submit', function(e){
-  e.preventDefault();
-  const lotSize = parseFloat(document.getElementById('lotSize').value);
-  const profit = parseFloat(document.getElementById('profit').value);
-  const resultDiv = document.getElementById('profitResultText');
-  if (!isNaN(lotSize) && !isNaN(profit) && lotSize !== 0) {
-    const result = (profit / lotSize) * 100;
-    resultDiv.textContent = `Profit Percentage: ${result.toFixed(2)}%`;
-  } else {
-    resultDiv.textContent = 'Please fill all fields.';
-  }
-});
+function toNumber(value) {
+  if (value === undefined || value === null) return null;
+  const num = parseFloat(String(value).replace(',', '.'));
+  return Number.isNaN(num) ? null : num;
+}
 
-// Compound interest
-document.getElementById('compoundInterestCalculator').addEventListener('submit', function(e){
-  e.preventDefault();
-  const initialInvestment = parseFloat(document.getElementById('initialInvestment').value);
-  const contribution = parseFloat(document.getElementById('contribution').value);
-  const rate = parseFloat(document.getElementById('rate').value) / 100;
-  const period = parseInt(document.getElementById('period').value);
-  const resultDiv = document.getElementById('compoundInterestResultText');
-  if (!isNaN(initialInvestment) && !isNaN(contribution) && !isNaN(rate) && !isNaN(period)) {
-    let finalAmount = initialInvestment * Math.pow(1 + rate, period);
-    for(let i = 1; i <= period; i++) {
-      finalAmount += contribution * Math.pow(1 + rate, period - i);
-    }
-    resultDiv.textContent = `Final Amount: $${finalAmount.toFixed(2)}`;
-  } else {
-    resultDiv.textContent = 'Please fill all fields.';
+function calculateExpression(form) {
+  const resultEl = form.querySelector('.result');
+  const expr = form.querySelector('#operationInput')?.value?.trim() ?? '';
+  if (!expr) return showError(form, 'Input required', resultEl);
+  try {
+    const result = math.evaluate(expr.replace(',', '.'));
+    resultEl.innerText = `Result: ${result}`;
+  } catch {
+    showError(form, 'Invalid expression', resultEl);
   }
-});
+}
 
-// B3 Profit Calculator
-document.getElementById('b3ProfitCalculator').addEventListener('submit', function(e){
-  e.preventDefault();
-  const contracts = parseInt(document.getElementById('contracts').value, 10);
-  const type = document.getElementById('type').value;
-  const points = parseFloat(document.getElementById('points').value);
-  const taxDeducted = document.getElementById('taxDeducted').checked;
-  const resultDiv = document.getElementById('b3ProfitResultText');
-  if (isNaN(contracts) || isNaN(points)) {
-    resultDiv.textContent = 'Please fill all fields.';
-    return;
+function calculateRuleOfThree(form) {
+  const resultEl = form.querySelector('.result');
+  const inputX = form.querySelector('#inputX');
+  const A = toNumber(form.querySelector('#inputA').value);
+  const B = toNumber(form.querySelector('#inputB').value);
+  const C = toNumber(form.querySelector('#inputC').value);
+  if (A === null || B === null || C === null) {
+    if (inputX) inputX.value = '';
+    return showError(form, 'Fill all fields.', resultEl);
   }
-  let multiplier = 1;
-  switch (type) {
-    case "miniIndice": multiplier = 0.2; break;
-    case "miniDolar":  multiplier = 10; break;
-    case "indice":     multiplier = 1; break;
-    case "dolar":      multiplier = 50; break;
+  if (A === 0) {
+    if (inputX) inputX.value = '';
+    return showError(form, 'A cannot be zero.', resultEl);
   }
-  let profit = contracts * points * multiplier;
-  if (taxDeducted) profit *= 0.8;
-  resultDiv.textContent = `Profit: R$ ${profit.toFixed(2)}${taxDeducted ? ' (after 20% tax)' : ''}`;
-});
+  const X = (B * C) / A;
+  if (!isFinite(X)) {
+    if (inputX) inputX.value = '';
+    return showError(form, 'Invalid calculation.', resultEl);
+  }
+  if (inputX) inputX.value = X.toFixed(2).replace('.', ',');
+  resultEl.innerText = `X = ${X.toFixed(2).replace('.', ',')}`;
+}
+
+function calculateLeverage(form) {
+  const resultEl = form.querySelector('.result');
+  const leverage = toNumber(form.querySelector('#leverage').value);
+  const percentage = toNumber(form.querySelector('#percentage').value);
+  if (leverage === null || percentage === null)
+    return showError(form, 'All fields required', resultEl);
+  const leveragedProfit = leverage * percentage;
+  resultEl.innerText = `Leveraged Profit: ${leveragedProfit.toFixed(2)}%`;
+}
+
+function calculateProfitPercentage(form) {
+  const resultEl = form.querySelector('.result');
+  const lotSize = toNumber(form.querySelector('#lotSize').value);
+  const profit = toNumber(form.querySelector('#profit').value);
+  if (lotSize === null || profit === null)
+    return showError(form, 'All fields required', resultEl);
+  if (lotSize === 0)
+    return showError(form, 'Lot size cannot be zero.', resultEl);
+  const profitPercent = (profit / lotSize) * 100;
+  resultEl.innerText = `Profit: ${profitPercent.toFixed(2)}%`;
+}
+
+function compoundInterestCalc(initialInvestment, contribution, annualRate, years, freq) {
+  const freqMap = { daily: 365, weekly: 52, monthly: 12, yearly: 1 };
+  const periodsPerYear = freqMap[freq];
+  if (!periodsPerYear) return NaN;
+  const ratePerPeriod = annualRate / 100 / periodsPerYear;
+  const totalPeriods = years * periodsPerYear;
+  let total = initialInvestment;
+  for (let i = 0; i < totalPeriods; i++) {
+    total = (total + contribution) * (1 + ratePerPeriod);
+  }
+  return total;
+}
+
+function calculateCompoundInterest(form) {
+  const resultEl = form.querySelector('.result');
+  const initialInvestment = toNumber(form.querySelector('#initialInvestment').value);
+  const contribution = toNumber(form.querySelector('#contribution').value) || 0;
+  const rate = toNumber(form.querySelector('#rate').value);
+  const years = toNumber(form.querySelector('#period').value);
+  const freq = form.querySelector('#compoundFrequency')?.value ?? 'monthly';
+  if (initialInvestment === null || rate === null || years === null)
+    return showError(form, 'Main fields required', resultEl);
+  const total = compoundInterestCalc(initialInvestment, contribution, rate, years, freq);
+  if (!isFinite(total)) return showError(form, 'Invalid calculation.', resultEl);
+  resultEl.innerText = `Total Value: ${total.toFixed(2)}`;
+}
+
+function b3ProfitCalc(contracts, points, type, taxDeducted) {
+  const contractValues = { miniIndice: 0.2, indice: 1, miniDolar: 10, dolar: 50 };
+  let total = contracts * contractValues[type] * points;
+  if (taxDeducted) total *= 0.8;
+  return total;
+}
+
+function calculateB3Profit(form) {
+  const resultEl = form.querySelector('.result');
+  const contracts = toNumber(form.querySelector('#contracts').value);
+  const points = toNumber(form.querySelector('#points').value);
+  const type = form.querySelector('#type').value;
+  const taxDeducted = form.querySelector('#taxDeducted').checked;
+  if (contracts === null || points === null)
+    return showError(form, 'All fields required', resultEl);
+  if ((type === 'dolar' || type === 'indice') && contracts % 5 !== 0)
+    return showError(form, 'Contracts must be multiples of 5 for Dollar and Index.', resultEl);
+  const total = b3ProfitCalc(contracts, points, type, taxDeducted);
+  resultEl.innerText = `Total Profit: ${total.toFixed(2)}`;
+}
+
+const handlers = {
+  calculator: calculateExpression,
+  ruleOfThreeCalculator: calculateRuleOfThree,
+  leverageCalculator: calculateLeverage,
+  profitCalculator: calculateProfitPercentage,
+  compoundInterestCalculator: calculateCompoundInterest,
+  b3ProfitCalculator: calculateB3Profit,
+};
+
+if (typeof document !== 'undefined') {
+  function createRipple(e) {
+    const button = e.currentTarget;
+    const circle = document.createElement('span');
+    const diameter = Math.max(button.clientWidth, button.clientHeight);
+    const radius = diameter / 2;
+    circle.classList.add('ripple-effect');
+    circle.style.width = circle.style.height = `${diameter}px`;
+    circle.style.left = `${e.clientX - button.getBoundingClientRect().left - radius}px`;
+    circle.style.top = `${e.clientY - button.getBoundingClientRect().top - radius}px`;
+    const ripple = button.getElementsByClassName('ripple-effect')[0];
+    if (ripple) ripple.remove();
+    button.appendChild(circle);
+  }
+
+  document.querySelectorAll('button').forEach(btn => {
+    btn.addEventListener('click', createRipple);
+  });
+
+  document.querySelectorAll('.toggle-button').forEach(btn => {
+    btn.addEventListener('click', () => showCalculator(btn.getAttribute('data-id')));
+  });
+
+  document.querySelectorAll('.calculator input, .calculator select').forEach(input => {
+    input.addEventListener('input', e => {
+      clearResult(e.target.closest('form'));
+      if (e.target.closest('form').id === 'ruleOfThreeCalculator') {
+        e.target.closest('form').querySelector('#inputX').value = '';
+      }
+    });
+  });
+
+  document.querySelectorAll('.calculator input').forEach(input => {
+    input.addEventListener('keypress', e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        input.closest('form').dispatchEvent(new Event('submit'));
+      }
+    });
+  });
+
+  document.querySelectorAll('form.calculator').forEach(form => {
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      clearResult(form);
+      const handler = handlers[form.id];
+      if (handler) handler(form);
+    });
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    setTimeout(() => {
+      const mainEl = document.querySelector('main');
+      if (mainEl) mainEl.classList.add('loaded');
+    }, 60);
+    showCalculator('calculator');
+  });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { compoundInterestCalc, b3ProfitCalc };
+}
+

--- a/style.css
+++ b/style.css
@@ -16,6 +16,7 @@ input[type=number] {
   --white: rgba(255,255,255,0.9);
   --white2: rgba(255,255,255,0.42);
   --white3: rgba(255,255,255,0.56);
+  --radius: 16px;
 }
 
 * {
@@ -81,7 +82,7 @@ body {
 .calculator {
   background-color: var(--card-bg);
   padding: 24px 20px;
-  border-radius: 18px;
+  border-radius: var(--radius);
   box-shadow: 0 2px 16px 0 rgba(0,0,0,0.18);
   width: 100%;
   min-width: 0;
@@ -106,16 +107,33 @@ select {
   padding: 10px;
   margin-top: 8px;
   margin-bottom: 16px;
-  border-radius: 8px;
+  border-radius: var(--radius);
   border: 2px solid var(--input-bg);
   background-color: var(--input-bg);
   box-sizing: border-box;
+  transition: border-color 0.3s;
+}
+
+input:focus,
+select:focus {
+  border-color: var(--white2);
+  outline: none;
+  border-radius: var(--radius);
+}
+
+input:disabled,
+select:disabled,
+textarea:disabled {
+  border: 2px solid transparent;
+  background-color: #444;
+  color: #999;
+  border-radius: var(--radius);
 }
 
 button[type="submit"] {
   padding: 12px;
   width: 100%;
-  border-radius: 16px;
+  border-radius: var(--radius);
   background-color: var(--accent-color);
   color: var(--white);
   border: none;
@@ -135,29 +153,35 @@ button[type="submit"]:focus {
   box-shadow: 0 0 0 3px rgba(98,0,238,0.3);
 }
 
-button[type="submit"]::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(255,255,255,0.3);
-  border-radius: 50%;
-  transform: scale(0);
-  opacity: 0;
-  transition: transform 0.3s, opacity 0.3s;
+
+button[type="submit"]:active {
+  box-shadow: 0 0 4px rgba(0,0,0,0.4);
 }
 
-button[type="submit"]:active::after {
-  transform: scale(2);
-  opacity: 1;
+.ripple-effect {
+  position: absolute;
+  border-radius: 50%;
+  transform: scale(0);
+  animation: ripple 600ms linear;
+  background-color: rgba(255,255,255,0.4);
+  pointer-events: none;
+  opacity: 0.75;
+}
+
+@keyframes ripple {
+  to {
+    transform: scale(4);
+    opacity: 0;
+  }
 }
 
 .result {
   margin-top: 20px;
   font-weight: bold;
   color: var(--white);
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  padding: 16px;
 }
 
 .rule-three-block {
@@ -171,6 +195,24 @@ button[type="submit"]:active::after {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.rule-three-row input {
+  width: 80px;
+  text-align: center;
+  font-size: 1.1em;
+  padding: 12px;
+  border-radius: var(--radius);
+  border: 2px solid var(--input-bg);
+  background: #222;
+  color: var(--white);
+  transition: border 0.17s;
+}
+
+.rule-three-row input:focus {
+  border: 2px solid var(--white3);
+  outline: none;
+  border-radius: var(--radius);
 }
 
 .rule-three-label {
@@ -211,6 +253,7 @@ label {
   align-items: center;
   gap: 8px;
   margin-top: 10px;
+  border-radius: var(--radius);
 }
 
 .mt-30 {


### PR DESCRIPTION
## Summary
- Refactor calculator logic into reusable functions with clearer validation and ripple button feedback
- Centralize rounding and color styling with a new --radius variable and consistent input/result designs

## Testing
- `node -e "require('./script.js')"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b36ac6dc8326b8a8df91af52e7cc