### PR TITLE
Align calculator titles with reference code

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CalcSlide</title>
+  <title>Calculators</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
@@ -13,7 +13,7 @@
   <div class="scroll-container" id="scrollContainer">
     <div class="calculators-list" id="calculatorsList">
       <form id="calculator" class="calculator">
-        <h2>Normal Calculator</h2>
+        <h2>Basic Calculator</h2>
         <label for="operationInput">Math Expression:</label>
         <input type="text" id="operationInput" placeholder="Type an operation" />
         <button type="submit">Calculate</button>
@@ -21,7 +21,7 @@
       </form>
 
       <form class="calculator" id="ruleOfThreeCalculator" autocomplete="off">
-        <h2>Rule of Three Calculator</h2>
+        <h2>Proportion Calculator</h2>
         <div class="rule-three-block">
           <div class="rule-three-row">
             <input type="number" id="inputA" step="any" placeholder="A" />
@@ -40,7 +40,7 @@
       </form>
 
       <form id="leverageCalculator" class="calculator">
-        <h2>Leverage Calculator</h2>
+        <h2>Leverage Profit Calculator</h2>
         <label>Leverage:</label>
         <input type="number" id="leverage" step="any" />
         <label>Percentage Earned (%):</label>
@@ -74,7 +74,7 @@
       </form>
 
       <form class="calculator" id="b3ProfitCalculator" autocomplete="off">
-        <h2>B3 Profit Calculator</h2>
+        <h2>B3 Futures Profit Calculator</h2>
         <div class="form-group">
           <label for="contracts">Contracts:</label>
           <input type="number" id="contracts" name="contracts" step="1" />


### PR DESCRIPTION
## Summary
- Rename calculator sections: Basic, Proportion, Leverage Profit, and B3 Futures Profit
- Update page title to "Calculators"

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b598cd28832687c7054f03d03fd3