### PR TITLE
Show calculators side by side

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,30 +14,9 @@
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
   </head>
   <body>
-    <div class="toggle-buttons">
-      <button class="toggle-button active" data-id="calculator">
-        Basic Calculator
-      </button>
-      <button class="toggle-button" data-id="ruleOfThreeCalculator">
-        Proportion Calculator
-      </button>
-      <button class="toggle-button" data-id="leverageCalculator">
-        Leverage Profit
-      </button>
-      <button class="toggle-button" data-id="profitCalculator">
-        Profit Percentage
-      </button>
-      <button class="toggle-button" data-id="compoundInterestCalculator">
-        Compound Interest
-      </button>
-      <button class="toggle-button" data-id="b3ProfitCalculator">
-        B3 Futures Profit
-      </button>
-    </div>
-
     <main>
       <section class="calculators">
-        <form class="calculator show" id="calculator" autocomplete="off">
+        <form class="calculator" id="calculator" autocomplete="off">
           <h2>Basic Calculator</h2>
           <p class="description">
             Perform basic arithmetic operations on any math expression.

--- a/script.js
+++ b/script.js
@@ -8,17 +8,6 @@ function showError(form, msg, resultEl) {
   if (el) el.innerText = 'Error: ' + msg;
 }
 
-function showCalculator(calculatorId) {
-  document
-    .querySelectorAll('.calculator')
-    .forEach(calc => calc.classList.remove('show'));
-  const target = document.getElementById(calculatorId);
-  if (target) target.classList.add('show');
-  document.querySelectorAll('.toggle-button').forEach(btn => {
-    btn.classList.toggle('active', btn.getAttribute('data-id') === calculatorId);
-  });
-}
-
 function toNumber(value) {
   if (value === undefined || value === null) return null;
   const num = parseFloat(String(value).replace(',', '.'));
@@ -158,10 +147,6 @@ if (typeof document !== 'undefined') {
     btn.addEventListener('click', createRipple);
   });
 
-  document.querySelectorAll('.toggle-button').forEach(btn => {
-    btn.addEventListener('click', () => showCalculator(btn.getAttribute('data-id')));
-  });
-
   document.querySelectorAll('.calculator input, .calculator select').forEach(input => {
     input.addEventListener('input', e => {
       clearResult(e.target.closest('form'));
@@ -194,7 +179,6 @@ if (typeof document !== 'undefined') {
       const mainEl = document.querySelector('main');
       if (mainEl) mainEl.classList.add('loaded');
     }, 60);
-    showCalculator('calculator');
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -27,7 +27,7 @@ body {
   flex-direction: column;
   align-items: center;
   margin: 0;
-  padding: 24px 16px 0 16px;
+  padding: 24px 16px;
   font-size: 16px;
 }
 
@@ -36,78 +36,27 @@ button {
   overflow: hidden;
 }
 
-.toggle-buttons {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 24px 0 16px 0;
-}
-
-.toggle-button {
-  padding: 16px 32px;
-  border: 2px solid var(--white2);
-  border-radius: 16px;
-  background-color: transparent;
-  color: var(--white);
-  cursor: pointer;
-  transition:
-    background-color 0.3s,
-    color 0.3s,
-    border-color 0.3s,
-    box-shadow 0.35s;
-}
-
-.toggle-button.active,
-.toggle-button:active {
-  background-color: transparent;
-  color: var(--white);
-  border: 2px solid var(--white3);
-  box-shadow: 0 0 4px 1px var(--white3);
-}
-
-.toggle-button:focus,
-.toggle-button:hover {
-  border: 2px solid var(--white3);
-  outline: 2px solid var(--white3);
-  border-radius: 16px;
-}
-
 .calculators {
-  position: relative;
-  min-height: 420px;
+  display: grid;
   width: 100%;
+  gap: 16px;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 600px) {
+  .calculators {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 24px;
+  }
 }
 
 .calculator {
-  opacity: 0;
-  pointer-events: none;
-  transform: translateY(32px);
-  transition:
-    opacity 0.8s cubic-bezier(0.23, 1.35, 0.38, 1),
-    transform 0.8s cubic-bezier(0.23, 1.35, 0.38, 1);
-  position: absolute;
-  width: 100%;
-  left: 0;
-  top: 0;
-  z-index: 0;
-  display: block;
-  max-width: 600px;
-  margin: 8px auto;
   background-color: var(--card-bg);
   padding: 24px;
   border-radius: 16px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.35);
   font-size: 16px;
   box-sizing: border-box;
-}
-
-.calculator.show {
-  opacity: 1;
-  pointer-events: auto;
-  transform: translateY(0);
-  z-index: 1;
-  position: relative;
 }
 
 .calculator .form-group {
@@ -237,11 +186,6 @@ main {
   transition: none;
 }
 
-@media (min-width: 769px) {
-  .calculator {
-    width: 500px;
-  }
-}
 
 input[type="number"]::-webkit-outer-spin-button,
 input[type="number"]::-webkit-inner-spin-button {


### PR DESCRIPTION
## Summary
- Remove top toggle buttons and display all calculator forms concurrently.
- Lay out calculators in a responsive grid with 16–24px gaps following Material Design spacing.
- Strip out JavaScript toggle logic now that forms are always visible.

## Testing
- `node -e "require('./script.js'); console.log('loaded');"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898bcd0799083268a0994bc0030b29f